### PR TITLE
fix: Parse deprecation message from expression arguments

### DIFF
--- a/src/griffe_warnings_deprecated/extension.py
+++ b/src/griffe_warnings_deprecated/extension.py
@@ -16,7 +16,7 @@ _decorators = {"warnings.deprecated", "typing_extensions.deprecated"}
 def _deprecated(obj: Class | Function) -> str | None:
     for decorator in obj.decorators:
         if decorator.callable_path in _decorators:
-            return str(decorator.value).split("(", 1)[1].rstrip(")").rsplit(",", 1)[0].lstrip("f")[1:-1]
+            return str(decorator.value.arguments[0]).lstrip("f")[1:-1]
     return None
 
 

--- a/src/griffe_warnings_deprecated/extension.py
+++ b/src/griffe_warnings_deprecated/extension.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from griffe import Class, Docstring, DocstringSectionAdmonition, Extension, Function, get_logger
+from griffe import Class, Docstring, DocstringSectionAdmonition, ExprCall, Extension, Function, get_logger
 
 logger = get_logger(__name__)
 self_namespace = "griffe_warnings_deprecated"
@@ -15,7 +15,7 @@ _decorators = {"warnings.deprecated", "typing_extensions.deprecated"}
 
 def _deprecated(obj: Class | Function) -> str | None:
     for decorator in obj.decorators:
-        if decorator.callable_path in _decorators:
+        if decorator.callable_path in _decorators and isinstance(decorator.value, ExprCall):
             return str(decorator.value.arguments[0]).lstrip("f")[1:-1]
     return None
 

--- a/src/griffe_warnings_deprecated/extension.py
+++ b/src/griffe_warnings_deprecated/extension.py
@@ -19,7 +19,7 @@ def _deprecated(obj: Class | Function) -> str | None:
         if decorator.callable_path in _decorators and isinstance(decorator.value, ExprCall):
             first_arg = decorator.value.arguments[0]
             try:
-                return ast.literal_eval(first_arg)  # type: ignore
+                return ast.literal_eval(first_arg)  # type: ignore[arg-type]
             except ValueError:
                 logger.debug("%s is not a static string", str(first_arg))
                 return None

--- a/src/griffe_warnings_deprecated/extension.py
+++ b/src/griffe_warnings_deprecated/extension.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 from typing import Any
 
 from griffe import Class, Docstring, DocstringSectionAdmonition, ExprCall, Extension, Function, get_logger
@@ -16,7 +17,8 @@ _decorators = {"warnings.deprecated", "typing_extensions.deprecated"}
 def _deprecated(obj: Class | Function) -> str | None:
     for decorator in obj.decorators:
         if decorator.callable_path in _decorators and isinstance(decorator.value, ExprCall):
-            return str(decorator.value.arguments[0]).lstrip("f")[1:-1]
+            message = str(decorator.value.arguments[0]).removeprefix("f")
+            return ast.literal_eval(message)
     return None
 
 

--- a/src/griffe_warnings_deprecated/extension.py
+++ b/src/griffe_warnings_deprecated/extension.py
@@ -17,8 +17,12 @@ _decorators = {"warnings.deprecated", "typing_extensions.deprecated"}
 def _deprecated(obj: Class | Function) -> str | None:
     for decorator in obj.decorators:
         if decorator.callable_path in _decorators and isinstance(decorator.value, ExprCall):
-            message = str(decorator.value.arguments[0]).removeprefix("f")
-            return ast.literal_eval(message)
+            first_arg = decorator.value.arguments[0]
+            try:
+                return ast.literal_eval(first_arg)  # type: ignore
+            except ValueError:
+                logger.debug("%s is not a static string", str(first_arg))
+                return None
     return None
 
 


### PR DESCRIPTION
Update the `deprecated` method to parse the deprecation message from the expression arguments instead of relying on string parsing.

Fixes https://github.com/mkdocstrings/griffe-warnings-deprecated/issues/4